### PR TITLE
Remove referência ao termo aditivo de antecipação

### DIFF
--- a/AsaasInsomniaCollection.json
+++ b/AsaasInsomniaCollection.json
@@ -2483,37 +2483,6 @@
             "_type": "request"
         },
         {
-            "_id": "req_3d01d1b601034ba0b640ba937b8b3319",
-            "parentId": "fld_009a73090a15449594c926a4336a8268",
-            "modified": 1677182593157,
-            "created": 1677182561059,
-            "url": "{{domain}}/v3/anticipations/agreement/sign",
-            "name": "Concordar ou discordar com Aditivo aos Termos de Uso do ASAAS para contratação do Serviço de Antecipação",
-            "description": "",
-            "method": "POST",
-            "body": {
-                "mimeType": "",
-                "text": "{\n  \"agreed\": true\n}"
-            },
-            "parameters": [],
-            "headers": [
-                {
-                    "name": "Content-Type",
-                    "value": "application/json"
-                }
-            ],
-            "authentication": {},
-            "metaSortKey": -1645211601096,
-            "isPrivate": false,
-            "settingStoreCookies": true,
-            "settingSendCookies": true,
-            "settingDisableRenderRequestBody": false,
-            "settingEncodeUrl": true,
-            "settingRebuildPath": true,
-            "settingFollowRedirects": "global",
-            "_type": "request"
-        },
-        {
             "_id": "req_0d40c3ade684441ba4b155f2ec6f77f7",
             "parentId": "fld_4480f8cd502246d180df4af4907298bd",
             "modified": 1645211601145,


### PR DESCRIPTION
## Descrição
- Atualmente o endpoint do termo aditivo de antecipação se encontra deprecado e retornando dados mockados enquanto aguardamos o envio de emails para os clientes que consomem o endpoint, já que não é mais necessário assinar o termo manualmente, uma vez que está inserido no termo geral do ASAAS. Portanto, estamos removendo também da collection do insomnia.

## Tarefa Jira
- [SKS-1352](https://asaasdev.atlassian.net/browse/SKS-1352?atlOrigin=eyJpIjoiZTY1ODE3M2I5OGNiNGM2OGIyMTRmYmI2OTdmZDM1YTEiLCJwIjoiaiJ9)
## PR no Asaas
- [PR que depreciou o enum](https://github.com/asaasdev/api-docs/pull/21)

[SKS-1352]: https://asaasdev.atlassian.net/browse/SKS-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ